### PR TITLE
chore(fmt): apply cargo fmt across workspace

### DIFF
--- a/apps/komet/src/daemon/win.rs
+++ b/apps/komet/src/daemon/win.rs
@@ -19,18 +19,14 @@ use std::ffi::OsString;
 #[cfg(target_os = "windows")]
 use std::path::Path;
 #[cfg(target_os = "windows")]
-use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(target_os = "windows")]
 use std::sync::Arc;
+#[cfg(target_os = "windows")]
+use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(target_os = "windows")]
 use std::time::Duration;
 
 #[cfg(target_os = "windows")]
 use anyhow::{Context, bail};
-#[cfg(target_os = "windows")]
-use winreg::enums::HKEY_LOCAL_MACHINE;
-#[cfg(target_os = "windows")]
-use winreg::RegKey;
 #[cfg(target_os = "windows")]
 use windows_service::service::{
     Service, ServiceAccess, ServiceControl, ServiceControlAccept, ServiceErrorControl,
@@ -40,6 +36,10 @@ use windows_service::service::{
 use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
 #[cfg(target_os = "windows")]
 use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+#[cfg(target_os = "windows")]
+use winreg::RegKey;
+#[cfg(target_os = "windows")]
+use winreg::enums::HKEY_LOCAL_MACHINE;
 
 #[cfg(target_os = "windows")]
 use super::{CAPTURED_ENV, SERVICE_NAME};
@@ -49,8 +49,7 @@ use super::{CAPTURED_ENV, SERVICE_NAME};
 const DISPLAY_NAME: &str = "Komet headless engine";
 #[cfg(target_os = "windows")]
 #[cfg(target_os = "windows")]
-const ENV_REGISTRY_PATH: &str =
-    r"SYSTEM\CurrentControlSet\Services\Komet\Parameters\Environment";
+const ENV_REGISTRY_PATH: &str = r"SYSTEM\CurrentControlSet\Services\Komet\Parameters\Environment";
 /// How long to wait for a StopPending → Stopped transition before giving up.
 #[cfg(target_os = "windows")]
 #[cfg(target_os = "windows")]
@@ -62,7 +61,8 @@ windows_service::define_windows_service!(ffi_service_main, service_main);
 #[cfg(target_os = "windows")]
 #[cfg(target_os = "windows")]
 fn manager(access: ServiceManagerAccess) -> anyhow::Result<ServiceManager> {
-    ServiceManager::local_computer(None::<&str>, access).context("opening the service control manager")
+    ServiceManager::local_computer(None::<&str>, access)
+        .context("opening the service control manager")
 }
 
 #[cfg(target_os = "windows")]
@@ -78,13 +78,15 @@ pub fn install(exe: &Path, env: &[(String, String)]) -> anyhow::Result<()> {
         let _ = service.delete();
     }
 
-    let (account_name, account_password, local_system) = match std::env::var("KOMET_SERVICE_PASSWORD")
-    {
-        Ok(password) if !password.trim().is_empty() => {
-            (Some(service_account_name()?.into()), Some(password.into()), false)
-        }
-        _ => (None, None, true),
-    };
+    let (account_name, account_password, local_system) =
+        match std::env::var("KOMET_SERVICE_PASSWORD") {
+            Ok(password) if !password.trim().is_empty() => (
+                Some(service_account_name()?.into()),
+                Some(password.into()),
+                false,
+            ),
+            _ => (None, None, true),
+        };
 
     let info = ServiceInfo {
         name: SERVICE_NAME.into(),
@@ -133,9 +135,10 @@ fn service_account_name() -> anyhow::Result<String> {
 #[cfg(target_os = "windows")]
 pub fn uninstall() -> anyhow::Result<bool> {
     let manager = manager(ServiceManagerAccess::CONNECT)?;
-    let Ok(service) =
-        manager.open_service(SERVICE_NAME, ServiceAccess::STOP | ServiceAccess::DELETE | ServiceAccess::QUERY_STATUS)
-    else {
+    let Ok(service) = manager.open_service(
+        SERVICE_NAME,
+        ServiceAccess::STOP | ServiceAccess::DELETE | ServiceAccess::QUERY_STATUS,
+    ) else {
         return Ok(false);
     };
     let _ = stop_and_wait(&service);
@@ -150,7 +153,9 @@ pub fn start() -> anyhow::Result<bool> {
     let Ok(service) = manager.open_service(SERVICE_NAME, ServiceAccess::START) else {
         return Ok(false);
     };
-    service.start(&[] as &[OsString]).context("starting the service")?;
+    service
+        .start(&[] as &[OsString])
+        .context("starting the service")?;
     Ok(true)
 }
 
@@ -158,7 +163,10 @@ pub fn start() -> anyhow::Result<bool> {
 pub fn stop() -> anyhow::Result<()> {
     let manager = manager(ServiceManagerAccess::CONNECT)?;
     let service = manager
-        .open_service(SERVICE_NAME, ServiceAccess::STOP | ServiceAccess::QUERY_STATUS)
+        .open_service(
+            SERVICE_NAME,
+            ServiceAccess::STOP | ServiceAccess::QUERY_STATUS,
+        )
         .with_context(|| format!("opening {SERVICE_NAME} (not installed?)"))?;
     stop_and_wait(&service)?;
     Ok(())
@@ -176,7 +184,9 @@ pub fn restart() -> anyhow::Result<()> {
     if service.query_status()?.current_state != ServiceState::Stopped {
         stop_and_wait(&service)?;
     }
-    service.start(&[] as &[OsString]).context("restarting the service")?;
+    service
+        .start(&[] as &[OsString])
+        .context("restarting the service")?;
     Ok(())
 }
 
@@ -324,8 +334,8 @@ fn service_main(_arguments: Vec<OsString>) {
     // The engine owns its tokio runtime; run it on a dedicated thread so the
     // service main can drive the stop handshake without blocking it.
     let engine_thread = std::thread::spawn(|| -> anyhow::Result<()> {
-        let runtime = tokio::runtime::Runtime::new()
-            .with_context(|| "failed to start the engine runtime")?;
+        let runtime =
+            tokio::runtime::Runtime::new().with_context(|| "failed to start the engine runtime")?;
         runtime.block_on(async {
             let engine = komet_engine::Engine::new(crate::engine_config_from_env());
             engine.run().await

--- a/crates/doc/examples/rebuild_whale.rs
+++ b/crates/doc/examples/rebuild_whale.rs
@@ -1,9 +1,9 @@
 //! Run the M1 thin rebuild against a REAL whale snapshot (read-only: loads a
 //! snapshot file, rebuilds, reports accounting — writes nothing anywhere).
 //! Usage: cargo run -p komet-doc --example rebuild_whale -- <snapshot.bin>
-use loro::LoroDoc;
 use komet_doc::rebuild::{doc_epoch, rebuild_thin_doc};
 use komet_doc::schema::SessionDoc;
+use loro::LoroDoc;
 
 fn main() {
     let path = std::env::args()

--- a/crates/engine/examples/sidecar_probe.rs
+++ b/crates/engine/examples/sidecar_probe.rs
@@ -3,9 +3,9 @@
 //! zero-blobs-in-prod mystery (refs stamped, uploads absent, no warns).
 use std::sync::Arc;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use komet_engine::doc_host::{DocHost, DocHostConfig, EdgeConfig};
 use komet_sync::DocsStore;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[tokio::main]
 async fn main() {

--- a/crates/engine/src/agent_accounts.rs
+++ b/crates/engine/src/agent_accounts.rs
@@ -1314,7 +1314,7 @@ mod wincred {
 
     use windows_sys::Win32::Foundation::FILETIME;
     use windows_sys::Win32::Security::Credentials::{
-        CredFree, CredReadW, CredWriteW, CREDENTIALW, CRED_PERSIST_LOCAL_MACHINE, CRED_TYPE_GENERIC,
+        CRED_PERSIST_LOCAL_MACHINE, CRED_TYPE_GENERIC, CREDENTIALW, CredFree, CredReadW, CredWriteW,
     };
 
     fn target() -> Vec<u16> {

--- a/crates/engine/src/local_import.rs
+++ b/crates/engine/src/local_import.rs
@@ -25,9 +25,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
 use komet_doc::{REGISTRY_DOC_ID, RegistryDoc};
 use komet_sync::DocsStore;
+use serde::{Deserialize, Serialize};
 
 use crate::EngineError;
 use crate::chat2_host::CHAT2_DOC_EPOCH;

--- a/crates/engine/src/profile.rs
+++ b/crates/engine/src/profile.rs
@@ -7,9 +7,9 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use komet_proto::WorkspaceScope;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use komet_proto::WorkspaceScope;
 
 use crate::EngineError;
 

--- a/crates/engine/src/registry.rs
+++ b/crates/engine/src/registry.rs
@@ -262,13 +262,13 @@ impl HarnessRegistry {
                         if let Ok(fresh) = harness.models().await
                             && !fresh.is_empty()
                         {
-                            cache
-                                .lock()
-                                .unwrap_or_else(PoisonError::into_inner)
-                                .insert(id, CachedModels {
+                            cache.lock().unwrap_or_else(PoisonError::into_inner).insert(
+                                id,
+                                CachedModels {
                                     discovered_at_ms: crate::now_ms(),
                                     models: fresh.clone(),
-                                });
+                                },
+                            );
                             if let Some(path) = path {
                                 let file = ModelsCacheFile {
                                     entries: cache
@@ -879,11 +879,7 @@ mod tests {
         reloaded.load_prefs(dir.path());
         reloaded.load_models_cache(dir.path());
         let cached = reloaded.models(HarnessId::Mock).await;
-        let ids: Vec<String> = cached
-            .unwrap()
-            .into_iter()
-            .map(|m| m.id)
-            .collect();
+        let ids: Vec<String> = cached.unwrap().into_iter().map(|m| m.id).collect();
         assert_eq!(ids, vec!["mock-1", "mock-fable-5"]);
     }
 

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -751,9 +751,9 @@ impl Inner {
                 context_limit,
             } => {
                 let mut usage_stats = lock(&self.usage_stats);
-                let entry = usage_stats
-                    .entry(chat_id.to_string())
-                    .or_insert_with(|| komet_proto::ContextUsageStats::new(context_limit.unwrap_or(200_000)));
+                let entry = usage_stats.entry(chat_id.to_string()).or_insert_with(|| {
+                    komet_proto::ContextUsageStats::new(context_limit.unwrap_or(200_000))
+                });
                 entry.ingest(
                     *input_tokens,
                     *cached_input_tokens,

--- a/crates/engine/tests/local_first.rs
+++ b/crates/engine/tests/local_first.rs
@@ -6,13 +6,13 @@ use std::sync::{Arc, Mutex};
 
 use base64::Engine as _;
 use futures::{SinkExt, StreamExt};
+use komet_engine::{AuthState, Engine, EngineConfig, EngineInfo, HarnessId, WorkspaceScope};
+use komet_rpc::{connect_ws, memory_client, methods};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tokio_tungstenite::tungstenite::handshake::server::{
     Request as WsRequest, Response as WsResponse,
 };
-use komet_engine::{AuthState, Engine, EngineConfig, EngineInfo, HarnessId, WorkspaceScope};
-use komet_rpc::{connect_ws, memory_client, methods};
 
 fn config(
     data_dir: &std::path::Path,

--- a/crates/engine/tests/local_profiles.rs
+++ b/crates/engine/tests/local_profiles.rs
@@ -3,12 +3,12 @@
 use std::path::Path;
 use std::sync::{Arc, Barrier, Mutex};
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
 use komet_engine::{
     AuthState, Engine, EngineConfig, EngineCore, EngineProfile, HarnessId, WorkspaceScope,
     default_registry,
 };
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 
 fn config(
     data_dir: &Path,

--- a/crates/harness/src/acp/cursor.rs
+++ b/crates/harness/src/acp/cursor.rs
@@ -12,8 +12,8 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use serde_json::Value;
 use komet_proto::{Model, ModelOption, ModelOptionChoice, ReasoningLevel};
+use serde_json::Value;
 
 /// Strip Cursor's effort-badge HTML from a model name and return the plain
 /// label plus the badge text when present.
@@ -575,8 +575,8 @@ pub(crate) fn effort_tokens(level: ReasoningLevel) -> Vec<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
     use komet_proto::Model;
+    use serde_json::json;
 
     #[test]
     fn clean_label_strips_span_badges_without_duplicating() {

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -957,7 +957,9 @@ impl AcpHarness {
             Ok::<Vec<Model>, HarnessError>(models)
         };
         let result = tokio::time::timeout(
-            self.spec.model_discovery_timeout.unwrap_or(Duration::from_secs(10)),
+            self.spec
+                .model_discovery_timeout
+                .unwrap_or(Duration::from_secs(10)),
             discovery,
         )
         .await;
@@ -1613,7 +1615,12 @@ fn usage_from_response(res: &Result<Value, HarnessError>) -> Option<AgentEvent> 
             .find_map(|k| usage.get(*k))
             .and_then(Value::as_u64)
     };
-    let input = count(&["inputTokens", "input_tokens", "promptTokens", "prompt_tokens"]);
+    let input = count(&[
+        "inputTokens",
+        "input_tokens",
+        "promptTokens",
+        "prompt_tokens",
+    ]);
     let cached = count(&[
         "cachedInputTokens",
         "cached_input_tokens",
@@ -1622,7 +1629,12 @@ fn usage_from_response(res: &Result<Value, HarnessError>) -> Option<AgentEvent> 
         "cachedTokens",
         "cached_tokens",
     ]);
-    let output = count(&["outputTokens", "output_tokens", "completionTokens", "completion_tokens"]);
+    let output = count(&[
+        "outputTokens",
+        "output_tokens",
+        "completionTokens",
+        "completion_tokens",
+    ]);
     let reasoning = count(&[
         "reasoningTokens",
         "reasoning_tokens",
@@ -1681,11 +1693,22 @@ fn friendly_prompt_error(err: &HarnessError) -> String {
     let raw = err.to_string();
     let lower = raw.to_lowercase();
     let credit = [
-        "credit", "quota", "insufficient balance", "billing", "payment", "top up",
-        "out of credits", "balance", "402",
+        "credit",
+        "quota",
+        "insufficient balance",
+        "billing",
+        "payment",
+        "top up",
+        "out of credits",
+        "balance",
+        "402",
     ];
     let rate = [
-        "rate limit", "too many requests", "throttl", "try again later", "retry after",
+        "rate limit",
+        "too many requests",
+        "throttl",
+        "try again later",
+        "retry after",
         "429",
     ];
     if credit.iter().any(|k| lower.contains(k)) {
@@ -3264,10 +3287,19 @@ mod tests {
         // Provider-side failures surface as `session/prompt: <message>`; the
         // known families must read as actionable notes, not transport errors.
         let cases = [
-            ("session/prompt: rate limit exceeded, please try again later", "Rate limited"),
+            (
+                "session/prompt: rate limit exceeded, please try again later",
+                "Rate limited",
+            ),
             ("session/prompt: too many requests (429)", "Rate limited"),
-            ("session/prompt: insufficient credits, please top up", "Out of credits"),
-            ("session/prompt: quota exceeded for the free tier", "Out of credits"),
+            (
+                "session/prompt: insufficient credits, please top up",
+                "Out of credits",
+            ),
+            (
+                "session/prompt: quota exceeded for the free tier",
+                "Out of credits",
+            ),
             ("session/prompt: payment required (402)", "Out of credits"),
             ("session/prompt: you are out of credits", "Out of credits"),
         ];

--- a/crates/harness/src/acp/normalize.rs
+++ b/crates/harness/src/acp/normalize.rs
@@ -8,8 +8,8 @@
 //! tagged `sessionUpdate`/snake_case; structs are camelCase; tool kinds and
 //! statuses are snake_case).
 
-use serde_json::Value;
 use komet_proto::{AgentEvent, SlashCommand, TodoItem, ToolCall, ToolDiff};
+use serde_json::Value;
 
 /// Byte cap applied to tool output text at the harness boundary. The doc-side
 /// fold applies its own (smaller) cap before anything persists; this one only

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -271,8 +271,8 @@ pub(crate) fn send_signal(pid: u32, signal: Signal) {
 #[cfg(windows)]
 pub(crate) fn send_signal(pid: u32, signal: Signal) {
     use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
-    use windows_sys::Win32::System::Console::{GenerateConsoleCtrlEvent, CTRL_C_EVENT};
-    use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+    use windows_sys::Win32::System::Console::{CTRL_C_EVENT, GenerateConsoleCtrlEvent};
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_TERMINATE, TerminateProcess};
 
     // SAFETY: we touch a pid we spawned and have not yet reaped. OpenProcess
     // with PROCESS_TERMINATE lets us both send a console Ctrl+C (when the

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -1615,11 +1615,13 @@ async fn opencode_models_come_from_the_wire_with_empty_ladder() {
     let harness = opencode_harness();
     let models = harness.models().await.expect("discovery");
     let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
-    assert_eq!(ids, vec!["opencode/big-pickle", "opencode/smol"], "{models:?}");
+    assert_eq!(
+        ids,
+        vec!["opencode/big-pickle", "opencode/smol"],
+        "{models:?}"
+    );
     assert!(
-        models
-            .iter()
-            .all(|m| m.reasoning_levels.is_empty()),
+        models.iter().all(|m| m.reasoning_levels.is_empty()),
         "{models:?}"
     );
     assert_eq!(models[0].description, None, "{models:?}");
@@ -1636,7 +1638,10 @@ async fn opencode_probe_failure_surfaces_as_an_error() {
     // seems frozen"). Catalog-backed harnesses still fall back to their
     // static list (covered by the catalog harnesses' own tests).
     let harness = AcpHarness::opencode().with_executable("/nonexistent/never-an-opencode-acp");
-    let err = harness.models().await.expect_err("wire-only probe failure errors");
+    let err = harness
+        .models()
+        .await
+        .expect_err("wire-only probe failure errors");
     assert!(matches!(err, HarnessError::NotInstalled(_)), "{err:?}");
 }
 
@@ -1655,7 +1660,12 @@ async fn opencode_launches_with_acp_args_and_runs_the_happy_path() {
     // spec's args land on the wire. Model ids are opencode-flavored, so the
     // run carries no model set and the chat settles.
     let (controls, _steer, _token) = controls();
-    let events = run_to_end(&opencode_harness(), request_opencode("scenario:happy", None), controls).await;
+    let events = run_to_end(
+        &opencode_harness(),
+        request_opencode("scenario:happy", None),
+        controls,
+    )
+    .await;
     assert!(events.contains(&AgentEvent::TextDelta {
         text: "Hello from opencode".into()
     }));

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -350,7 +350,11 @@ pub struct ContextUsageStats {
 
 impl ContextUsageStats {
     pub fn new(context_limit: u64) -> Self {
-        let limit = if context_limit == 0 { 200_000 } else { context_limit };
+        let limit = if context_limit == 0 {
+            200_000
+        } else {
+            context_limit
+        };
         Self {
             input_tokens: 0,
             cached_input_tokens: 0,
@@ -383,7 +387,14 @@ impl ContextUsageStats {
     }
 
     /// Ingest a new usage event into the session's cumulative metrics.
-    pub fn ingest(&mut self, input: u64, cached: u64, output: u64, reasoning: u64, limit: Option<u64>) {
+    pub fn ingest(
+        &mut self,
+        input: u64,
+        cached: u64,
+        output: u64,
+        reasoning: u64,
+        limit: Option<u64>,
+    ) {
         if input > 0 {
             self.input_tokens = self.input_tokens.saturating_add(input);
         }
@@ -408,9 +419,13 @@ impl ContextUsageStats {
 /// Helper to estimate default context limits from model names.
 pub fn default_context_limit_for_model(model_name: &str) -> u64 {
     let lower = model_name.to_lowercase();
-    if lower.contains("gemini-1.5") || lower.contains("gemini-2.0") || lower.contains("gemini-2.5") {
+    if lower.contains("gemini-1.5") || lower.contains("gemini-2.0") || lower.contains("gemini-2.5")
+    {
         1_000_000
-    } else if lower.contains("claude-3-7") || lower.contains("claude-3-5") || lower.contains("claude-3") {
+    } else if lower.contains("claude-3-7")
+        || lower.contains("claude-3-5")
+        || lower.contains("claude-3")
+    {
         200_000
     } else if lower.contains("deepseek") {
         128_000
@@ -512,8 +527,14 @@ mod tests {
 
     #[test]
     fn default_context_limit_detection() {
-        assert_eq!(default_context_limit_for_model("claude-3-7-sonnet"), 200_000);
-        assert_eq!(default_context_limit_for_model("gemini-2.0-flash"), 1_000_000);
+        assert_eq!(
+            default_context_limit_for_model("claude-3-7-sonnet"),
+            200_000
+        );
+        assert_eq!(
+            default_context_limit_for_model("gemini-2.0-flash"),
+            1_000_000
+        );
         assert_eq!(default_context_limit_for_model("deepseek-v3"), 128_000);
         assert_eq!(default_context_limit_for_model("gpt-4o"), 128_000);
     }

--- a/crates/sync/examples/chat2_live.rs
+++ b/crates/sync/examples/chat2_live.rs
@@ -12,9 +12,9 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
 use std::sync::{Arc, Mutex};
 
 use futures::future::BoxFuture;
-use loro::{ExportMode, LoroDoc, VersionVector};
 use komet_sync::SyncError;
 use komet_sync::chat_client::{ChatClient, ChatDocSink, CheckpointFetcher};
+use loro::{ExportMode, LoroDoc, VersionVector};
 
 struct DocSink {
     doc: Mutex<LoroDoc>,

--- a/crates/sync/examples/doc_surgery.rs
+++ b/crates/sync/examples/doc_surgery.rs
@@ -4,9 +4,9 @@
 //!   inspect-workspace <data_dir> <chat_id>
 //!   inspect-chat      <data_dir> <chat_id>
 //!   cut-chat          <data_dir> <chat_id> <from_index>
-use loro::{LoroDoc, ToJson};
 use komet_doc::SessionDoc;
 use komet_sync::DocsStore;
+use loro::{LoroDoc, ToJson};
 
 fn load_doc(store: &DocsStore, doc_id: &str) -> LoroDoc {
     let bytes = store

--- a/crates/ui/src/context_usage.rs
+++ b/crates/ui/src/context_usage.rs
@@ -33,12 +33,7 @@ pub fn render_context_ring(stats: &ContextUsageStats, theme: &Theme) -> AnyEleme
         .border_1()
         .border_color(theme.border)
         .bg(theme.surface)
-        .child(
-            div()
-                .size(px(inner_size))
-                .rounded_full()
-                .bg(ring_color),
-        )
+        .child(div().size(px(inner_size)).rounded_full().bg(ring_color))
         .into_any_element()
 }
 
@@ -130,11 +125,7 @@ pub fn render_context_popover(stats: &ContextUsageStats, theme: &Theme) -> AnyEl
                         .items_center()
                         .justify_between()
                         .text_xs()
-                        .child(
-                            div()
-                                .text_color(theme.text_muted)
-                                .child("Compacts at"),
-                        )
+                        .child(div().text_color(theme.text_muted).child("Compacts at"))
                         .child(
                             div()
                                 .font_family(theme.font_mono.clone())
@@ -178,7 +169,11 @@ pub fn render_context_popover(stats: &ContextUsageStats, theme: &Theme) -> AnyEl
                     format_tokens(stats.cached_input_tokens),
                     theme,
                 ))
-                .child(usage_row("Output", format_tokens(stats.output_tokens), theme))
+                .child(usage_row(
+                    "Output",
+                    format_tokens(stats.output_tokens),
+                    theme,
+                ))
                 .child(usage_row(
                     "Reasoning output (included)",
                     format_tokens(stats.reasoning_tokens),

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -77,8 +77,8 @@ fn register_fonts(cx: &App) {
     }
 }
 
-pub use state::EngineBootConfig;
 pub use komet_proto::HarnessId;
+pub use state::EngineBootConfig;
 
 /// Everything the headed binary passes in (config/env resolution lives in
 /// `apps/komet`, not here).

--- a/crates/ui/src/loaders.rs
+++ b/crates/ui/src/loaders.rs
@@ -9,16 +9,16 @@
 //! are paint-local and never move surrounding layout. Reduced motion snaps every
 //! cell to its rest state automatically (gpui `reduce_motion`).
 
-use gpui::{AnyElement, App, EntityId, IntoElement, ParentElement, SharedString, Styled, div, px};
 use crate::icons;
+use gpui::{AnyElement, App, EntityId, IntoElement, ParentElement, SharedString, Styled, div, px};
 
-use crate::motion::{self, GRADIENT_SPIN, PULSE_STAGGER, SPLASH_OUT, KOMET_PULSE};
+use crate::motion::{self, GRADIENT_SPIN, KOMET_PULSE, PULSE_STAGGER, SPLASH_OUT};
 use crate::theme::Theme;
 
 // Shared with the terminal viewport (`komet_proto::motion`) so both animate the
 // same loaders from the same numbers.
 pub use komet_proto::motion::{
-    MARK_CELLS, MARK_SPREAD, MATRIX_SIDE, KOMET_CELLS, mark_cell_stagger,
+    KOMET_CELLS, MARK_CELLS, MARK_SPREAD, MATRIX_SIDE, mark_cell_stagger,
 };
 
 /// The animated komet mark (komet-loader.tsx `KometLoader`): the full logo
@@ -114,10 +114,7 @@ pub use komet_proto::motion::{GSPIN_DIM, GSPIN_ROW_TINTS};
 pub use crate::thinking_orbs::{Dot, Line, OrbFrame, OrbState, ThinkingOrb, thinking_orb};
 
 /// Inline mini thinking orb for status-dot / session row slots.
-pub fn mini_thinking_orb(
-    state: OrbState,
-    size_px: f32,
-) -> ThinkingOrb {
+pub fn mini_thinking_orb(state: OrbState, size_px: f32) -> ThinkingOrb {
     ThinkingOrb::new(state, size_px)
 }
 

--- a/crates/ui/src/syntax_cache.rs
+++ b/crates/ui/src/syntax_cache.rs
@@ -8,8 +8,8 @@ use std::{
     sync::Arc,
 };
 
-use sha2::{Digest, Sha256};
 use komet_syntax::{HighlightedDocument, LanguageId};
+use sha2::{Digest, Sha256};
 
 pub const QUERY_GENERATION: u32 = 1;
 const MAX_DOCUMENTS: usize = 96;

--- a/crates/ui/src/thinking_orbs.rs
+++ b/crates/ui/src/thinking_orbs.rs
@@ -463,12 +463,7 @@ fn solve_cycle(time: f32, count: usize, slot_dur: f32, rest: f32) -> (Vec<f32>, 
     (amount, active)
 }
 
-fn apply_moves(
-    mut pt: [f32; 3],
-    moves: &[Move],
-    amount: &[f32],
-    active: i32,
-) -> ([f32; 3], bool) {
+fn apply_moves(mut pt: [f32; 3], moves: &[Move], amount: &[f32], active: i32) -> ([f32; 3], bool) {
     let mut in_active = false;
     for (i, mv) in moves.iter().enumerate() {
         if amount[i] <= 0.0 {
@@ -680,8 +675,7 @@ fn frame_web(size: f32, t: f32, speed_mul: f32, count_mul: f32, size_mul: f32) -
                     w: (0.8 * proximity * rs).max(0.5),
                 });
 
-                let sig_phase =
-                    (time * 0.6 + hash_d(i as f32, j as f32) * 10.0).rem_euclid(1.0);
+                let sig_phase = (time * 0.6 + hash_d(i as f32, j as f32) * 10.0).rem_euclid(1.0);
                 let px = sx1 + (sx2 - sx1) * sig_phase;
                 let py = sy1 + (sy2 - sy1) * sig_phase;
                 let pz = sz1 + (sz2 - sz1) * sig_phase;
@@ -764,8 +758,7 @@ fn frame_braid(size: f32, t: f32, speed_mul: f32, count_mul: f32, size_mul: f32)
             let py = u * r_sphere * breathing;
             let pz = angle.sin() * f;
 
-            let (sx, sy, sz) =
-                project_point(px, py, pz, time * 0.4, 0.3, cx, cy, 1.0);
+            let (sx, sy, sz) = project_point(px, py, pz, time * 0.4, 0.3, cx, cy, 1.0);
             let depth = (sz / r_sphere + 1.0) / 2.0;
 
             dots.push(Dot {
@@ -842,8 +835,7 @@ fn frame_ribbon(size: f32, t: f32, speed_mul: f32, count_mul: f32, size_mul: f32
             let py = by + vy * lane_offset * r_sphere;
             let pz = bz + vz * lane_offset * r_sphere;
 
-            let (sx, sy, sz) =
-                project_point(px, py, pz, time * 0.1, 0.3, cx, cy, 1.0);
+            let (sx, sy, sz) = project_point(px, py, pz, time * 0.1, 0.3, cx, cy, 1.0);
             let depth = (sz / r_sphere + 1.0) / 2.0;
 
             dots.push(Dot {


### PR DESCRIPTION
Reformat 23 files to match rustfmt edition 2024 defaults: import ordering, match-arm wrapping, long-line breaks, and whitespace normalization. No logic changes.

🤖 Generated with Codebuff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized code formatting and import ordering across Windows services, engine, synchronization, harness, protocol, and UI components.
  * Simplified several UI builder expressions without changing appearance or behavior.
  * Improved consistency in conditional logic, function signatures, and public export ordering.

* **Tests**
  * Reformatted integration and unit test code for improved readability.

* **User Impact**
  * No observable functionality, API behavior, or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->